### PR TITLE
make keys endpoint public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,8 @@ fn build_client() -> surf::Client {
 /// Describes optional config when creating a new Verifier
 #[derive(Debug)]
 pub struct Config {
-    keys_endpoint: Option<String>,
+    /// The endpoint to retrieve json web keys from
+    pub keys_endpoint: Option<String>,
 }
 
 impl Default for Config {


### PR DESCRIPTION
Apologies @06chaynes, seems like the keys_endpoint is private so had to make it public so we can use it as described in the readme. 