### PR TITLE
fix: disable reqwest default-features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "okta-jwt-verifier"
 description = "A helper library for working with JWT's for Okta in Rust"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Christian Haynes <06chaynes@gmail.com>"]
 repository = "https://github.com/06chaynes/okta-jwt-verifier.git"
 readme = "README.md"
@@ -19,7 +19,7 @@ jsonwebtoken = "9.3.0"
 serde = { version = "1.0.178", features = ["derive"] }
 serde_json = "1.0.104"
 surf = { version = "2.3.2", optional = true }
-reqwest = { version = "0.12.8", features = ["json"], optional = true }
+reqwest = { version = "0.12.8", default-features = false, features = ["json"], optional = true }
 reqwest-middleware = { version = "0.3.3", optional = true }
 http-cache-surf = { version = "0.13.0", optional = true }
 http-cache-reqwest = { version = "0.14.0", optional = true }


### PR DESCRIPTION
Hello,

This PR simply disables `reqwest` default features, that were forcing `openssl` between the dependencies.

This way it's possible to use only `rustls` (e.g. in environments without libssl installed)

All tests are still passing, since it doesn't break any API I've done a patch bump

Best regards